### PR TITLE
Add trace hook to clar

### DIFF
--- a/clar.c
+++ b/clar.c
@@ -132,6 +132,10 @@ static struct {
 
 	jmp_buf trampoline;
 	int trampoline_enabled;
+
+	cl_trace_cb *pfn_trace_cb;
+	void *trace_payload;
+
 } _clar;
 
 struct clar_func {
@@ -163,6 +167,23 @@ static int clar_sandbox(void);
 /* Load the declarations for the test suite */
 #include "clar.suite"
 
+
+#define CL_TRACE(ev)													\
+	do {																\
+		if (_clar.pfn_trace_cb)											\
+			_clar.pfn_trace_cb(ev,										\
+							   _clar.active_suite,						\
+							   _clar.active_test,						\
+							   _clar.trace_payload);					\
+	} while (0)
+
+void cl_trace_register(cl_trace_cb *cb, void *payload)
+{
+	_clar.pfn_trace_cb = cb;
+	_clar.trace_payload = payload;
+}
+
+
 /* Core test functions */
 static void
 clar_report_errors(void)
@@ -191,11 +212,15 @@ clar_run_test(
 	_clar.test_status = CL_TEST_OK;
 	_clar.trampoline_enabled = 1;
 
+	CL_TRACE(CL_TRACE__TEST__BEGIN);
+
 	if (setjmp(_clar.trampoline) == 0) {
 		if (initialize->ptr != NULL)
 			initialize->ptr();
 
+		CL_TRACE(CL_TRACE__TEST__RUN_BEGIN);
 		test->ptr();
+		CL_TRACE(CL_TRACE__TEST__RUN_END);
 	}
 
 	_clar.trampoline_enabled = 0;
@@ -205,6 +230,8 @@ clar_run_test(
 
 	if (cleanup->ptr != NULL)
 		cleanup->ptr();
+
+	CL_TRACE(CL_TRACE__TEST__END);
 
 	_clar.tests_ran++;
 
@@ -235,6 +262,8 @@ clar_run_suite(const struct clar_suite *suite, const char *filter)
 		clar_print_onsuite(suite->name, ++_clar.suites_ran);
 
 	_clar.active_suite = suite->name;
+	_clar.active_test = NULL;
+	CL_TRACE(CL_TRACE__SUITE_BEGIN);
 
 	if (filter) {
 		size_t suitelen = strlen(suite->name);
@@ -259,6 +288,9 @@ clar_run_suite(const struct clar_suite *suite, const char *filter)
 		if (_clar.exit_on_error && _clar.total_errors)
 			return;
 	}
+
+	_clar.active_test = NULL;
+	CL_TRACE(CL_TRACE__SUITE_END);
 }
 
 static void
@@ -424,6 +456,7 @@ static void abort_test(void)
 		exit(-1);
 	}
 
+	CL_TRACE(CL_TRACE__TEST__LONGJMP);
 	longjmp(_clar.trampoline, -1);
 }
 

--- a/clar.h
+++ b/clar.h
@@ -26,6 +26,48 @@ const char *clar_sandbox_path(void);
 void cl_set_cleanup(void (*cleanup)(void *), void *opaque);
 void cl_fs_cleanup(void);
 
+/**
+ * cl_trace_* is a hook to provide a simple global tracing
+ * mechanism.
+ *
+ * The goal here is to let main() provide clar-proper
+ * with a callback to optionally write log info for
+ * test operations into the same stream used by their
+ * actual tests.  This would let them print test names
+ * and maybe performance data as they choose.
+ *
+ * The goal is NOT to alter the flow of control or to
+ * override test selection/skipping.  (So the callback
+ * does not return a value.)
+ *
+ * The goal is NOT to duplicate the existing
+ * pass/fail/skip reporting.  (So the callback
+ * does not accept a status/errorcode argument.)
+ *
+ */
+typedef enum cl_trace_event {
+	CL_TRACE__SUITE_BEGIN,
+	CL_TRACE__SUITE_END,
+	CL_TRACE__TEST__BEGIN,
+	CL_TRACE__TEST__END,
+	CL_TRACE__TEST__RUN_BEGIN,
+	CL_TRACE__TEST__RUN_END,
+	CL_TRACE__TEST__LONGJMP,
+} cl_trace_event;
+
+typedef void (cl_trace_cb)(
+	cl_trace_event ev,
+	const char *suite_name,
+	const char *test_name,
+	void *payload);
+
+/**
+ * Register a callback into CLAR to send global trace events.
+ * Pass NULL to disable.
+ */
+void cl_trace_register(cl_trace_cb *cb, void *payload);
+
+
 #ifdef CLAR_FIXTURE_PATH
 const char *cl_fixture(const char *fixture_name);
 void cl_fixture_sandbox(const char *fixture_name);


### PR DESCRIPTION
This commit adds a hook to let the test application to request trace events when suites and tests are started and finished.

This can be used by the application to write log/trace messages to the same log stream used by their actual tests.

I have an demonstration in https://github.com/jeffhostetler/public_libgit2 in branch jeffhostetler/wip/clar_trace2
