### PR TITLE
Make '-s' imply '-i'

### DIFF
--- a/clar.c
+++ b/clar.c
@@ -346,7 +346,7 @@ clar_parse_args(int argc, char **argv)
 						_clar.report_suite_names = 1;
 
 					switch (action) {
-					case 's': clar_run_suite(&_clar_suites[j], argument); break;
+					case 's': _clar_suites[j].enabled = 1; clar_run_suite(&_clar_suites[j], argument); break;
 					case 'i': _clar_suites[j].enabled = 1; break;
 					case 'x': _clar_suites[j].enabled = 0; break;
 					}


### PR DESCRIPTION
If I have some tests disabled by default (say, the `online` tests), and run `clar -sonline::clone`, then I expect it to run only `online::clone`.  Since those are disabled though, it falls out of that and runs everything.