### PR TITLE
support hierarchical test resource data

### DIFF
--- a/clar/fixtures.h
+++ b/clar/fixtures.h
@@ -20,6 +20,19 @@ fixture_path(const char *base, const char *fixture_name)
 	return _path;
 }
 
+static const char *
+fixture_basename(const char *fixture_name)
+{
+	const char *p;
+
+	for (p = fixture_name; *p; p++) {
+		if (p[0] == '/' && p[1] && p[1] != '/')
+			fixture_name = p+1;
+	}
+
+	return fixture_name;
+}
+
 #ifdef CLAR_FIXTURE_PATH
 const char *cl_fixture(const char *fixture_name)
 {
@@ -33,6 +46,6 @@ void cl_fixture_sandbox(const char *fixture_name)
 
 void cl_fixture_cleanup(const char *fixture_name)
 {
-	fs_rm(fixture_path(_clar_path, fixture_name));
+	fs_rm(fixture_path(_clar_path, fixture_basename(fixture_name)));
 }
 #endif


### PR DESCRIPTION
Support hierarchical test resource data, such that you can have
`tests/resources/foo/bar` and move the `bar` directory in as
a fixture.

Calling `cl_fixture_sandbox` on a path that is not directly beneath
the test resources directory succeeds, placing that directory into
the test fixture.  (For example, `cl_fixture_sandbox("foo/bar")`
will sandbox the `foo/bar` directory as `bar`).

Add support for cleaning up directories created this way, by only
cleaning up the basename (in this example, `bar`) from the fixture
directory.