### PR TITLE
sandbox: check chdir return code

### DIFF
--- a/clar/sandbox.h
+++ b/clar/sandbox.h
@@ -65,7 +65,7 @@ static void clar_unsandbox(void)
 	if (_clar_path[0] == '\0')
 		return;
 
-	chdir("..");
+	cl_must_pass(chdir(".."));
 
 	fs_rm(_clar_path);
 }


### PR DESCRIPTION
Some compilers are getting whiny about ignoring the return code.