### PR TITLE
Known breakage

### DIFF
--- a/clar.c
+++ b/clar.c
@@ -508,11 +508,23 @@ void clar__skip(void)
 	abort_test();
 }
 
-void clar__broken(void)
+void clar__broken(
+	int condition,
+	const char *file,
+	int line,
+	const char *error,
+	const char *description,
+	int should_abort)
 {
-	_clar.test_status = CL_TEST_BROKEN;
-	_clar.total_broken++;
-	abort_test();
+	if (condition) {
+		_clar.total_broken++;
+		_clar.test_status = CL_TEST_BROKEN;
+	} else {
+		clar_set_error(file, line, error, description, CL_TEST_UNBROKEN);
+	}
+
+	if (should_abort)
+		abort_test();
 }
 
 void clar__fail(

--- a/clar.c
+++ b/clar.c
@@ -204,6 +204,37 @@ clar_report_errors(void)
 }
 
 static void
+clar_set_error(
+	const char *file,
+	int line,
+	const char *error_msg,
+	const char *description)
+{
+	struct clar_error *error = calloc(1, sizeof(struct clar_error));
+
+	if (_clar.errors == NULL)
+		_clar.errors = error;
+
+	if (_clar.last_error != NULL)
+		_clar.last_error->next = error;
+
+	_clar.last_error = error;
+
+	error->test = _clar.active_test;
+	error->test_number = _clar.tests_ran;
+	error->suite = _clar.active_suite;
+	error->file = file;
+	error->line_number = line;
+	error->error_msg = error_msg;
+
+	if (description != NULL)
+		error->description = strdup(description);
+
+	_clar.total_errors++;
+	_clar.test_status = CL_TEST_FAILURE;
+}
+
+static void
 clar_run_test(
 	const struct clar_func *test,
 	const struct clar_func *initialize,
@@ -480,28 +511,7 @@ void clar__fail(
 	const char *description,
 	int should_abort)
 {
-	struct clar_error *error = calloc(1, sizeof(struct clar_error));
-
-	if (_clar.errors == NULL)
-		_clar.errors = error;
-
-	if (_clar.last_error != NULL)
-		_clar.last_error->next = error;
-
-	_clar.last_error = error;
-
-	error->test = _clar.active_test;
-	error->test_number = _clar.tests_ran;
-	error->suite = _clar.active_suite;
-	error->file = file;
-	error->line_number = line;
-	error->error_msg = error_msg;
-
-	if (description != NULL)
-		error->description = strdup(description);
-
-	_clar.total_errors++;
-	_clar.test_status = CL_TEST_FAILURE;
+	clar_set_error(file, line, error_msg, description);
 
 	if (should_abort)
 		abort_test();

--- a/clar.c
+++ b/clar.c
@@ -100,6 +100,7 @@ struct clar_error {
 	const char *suite;
 	const char *file;
 	int line_number;
+	enum cl_test_status status;
 	const char *error_msg;
 	char *description;
 
@@ -208,7 +209,8 @@ clar_set_error(
 	const char *file,
 	int line,
 	const char *error_msg,
-	const char *description)
+	const char *description,
+	enum cl_test_status status)
 {
 	struct clar_error *error = calloc(1, sizeof(struct clar_error));
 
@@ -225,13 +227,14 @@ clar_set_error(
 	error->suite = _clar.active_suite;
 	error->file = file;
 	error->line_number = line;
+	error->status = status;
 	error->error_msg = error_msg;
 
 	if (description != NULL)
 		error->description = strdup(description);
 
 	_clar.total_errors++;
-	_clar.test_status = CL_TEST_FAILURE;
+	_clar.test_status = status;
 }
 
 static void
@@ -511,7 +514,7 @@ void clar__fail(
 	const char *description,
 	int should_abort)
 {
-	clar_set_error(file, line, error_msg, description);
+	clar_set_error(file, line, error_msg, description, CL_TEST_FAILURE);
 
 	if (should_abort)
 		abort_test();

--- a/clar.c
+++ b/clar.c
@@ -117,6 +117,7 @@ static struct {
 
 	int total_skipped;
 	int total_errors;
+	int total_broken;
 
 	int tests_ran;
 	int suites_ran;
@@ -504,6 +505,13 @@ void clar__skip(void)
 {
 	_clar.test_status = CL_TEST_SKIP;
 	_clar.total_skipped++;
+	abort_test();
+}
+
+void clar__broken(void)
+{
+	_clar.test_status = CL_TEST_BROKEN;
+	_clar.total_broken++;
 	abort_test();
 }
 

--- a/clar.h
+++ b/clar.h
@@ -13,7 +13,8 @@ enum cl_test_status {
 	CL_TEST_OK,
 	CL_TEST_FAILURE,
 	CL_TEST_SKIP,
-	CL_TEST_BROKEN
+	CL_TEST_BROKEN,
+	CL_TEST_UNBROKEN
 };
 
 void clar_test_init(int argc, char *argv[]);
@@ -80,6 +81,7 @@ void cl_fixture_cleanup(const char *fixture_name);
  */
 #define cl_must_pass_(expr, desc) clar__assert((expr) >= 0, __FILE__, __LINE__, "Function call failed: " #expr, desc, 1)
 #define cl_must_fail_(expr, desc) clar__assert((expr) < 0, __FILE__, __LINE__, "Expected function call to fail: " #expr, desc, 1)
+#define cl_must_break_(expr, desc) clar__broken((expr) == 0, __FILE__, __LINE__, "Expected function call to break: " #expr, desc, 1)
 #define cl_assert_(expr, desc) clar__assert((expr) != 0, __FILE__, __LINE__, "Expression is not true: " #expr, desc, 1)
 
 /**
@@ -87,6 +89,7 @@ void cl_fixture_cleanup(const char *fixture_name);
  */
 #define cl_check_pass_(expr, desc) clar__assert((expr) >= 0, __FILE__, __LINE__, "Function call failed: " #expr, desc, 0)
 #define cl_check_fail_(expr, desc) clar__assert((expr) < 0, __FILE__, __LINE__, "Expected function call to fail: " #expr, desc, 0)
+#define cl_check_break_(expr, desc) clar__broken((expr) == 0, __FILE__, __LINE__, "Expected function call to break: " #expr, desc, 0)
 #define cl_check_(expr, desc) clar__assert((expr) != 0, __FILE__, __LINE__, "Expression is not true: " #expr, desc, 0)
 
 /**
@@ -94,6 +97,7 @@ void cl_fixture_cleanup(const char *fixture_name);
  */
 #define cl_must_pass(expr) cl_must_pass_(expr, NULL)
 #define cl_must_fail(expr) cl_must_fail_(expr, NULL)
+#define cl_must_break(expr) cl_must_break_(expr, NULL)
 #define cl_assert(expr) cl_assert_(expr, NULL)
 
 /**
@@ -101,6 +105,7 @@ void cl_fixture_cleanup(const char *fixture_name);
  */
 #define cl_check_pass(expr) cl_check_pass_(expr, NULL)
 #define cl_check_fail(expr) cl_check_fail_(expr, NULL)
+#define cl_check_break(expr) cl_check_break_(expr, NULL)
 #define cl_check(expr) cl_check_(expr, NULL)
 
 /**
@@ -108,7 +113,7 @@ void cl_fixture_cleanup(const char *fixture_name);
  */
 #define cl_fail(desc) clar__fail(__FILE__, __LINE__, "Test failed.", desc, 1)
 #define cl_warning(desc) clar__fail(__FILE__, __LINE__, "Warning during test execution:", desc, 0)
-#define cl_break(desc) clar__broken()
+#define cl_break(desc) clar__broken(1, __FILE__, __LINE__, "Known breakage.", desc, 1)
 
 #define cl_skip() clar__skip()
 
@@ -137,7 +142,13 @@ void cl_fixture_cleanup(const char *fixture_name);
 
 void clar__skip(void);
 
-void clar__broken(void);
+void clar__broken(
+	int condition,
+	const char *file,
+	int line,
+	const char *error,
+	const char *description,
+	int should_abort);
 
 void clar__fail(
 	const char *file,

--- a/clar.h
+++ b/clar.h
@@ -12,7 +12,8 @@
 enum cl_test_status {
 	CL_TEST_OK,
 	CL_TEST_FAILURE,
-	CL_TEST_SKIP
+	CL_TEST_SKIP,
+	CL_TEST_BROKEN
 };
 
 void clar_test_init(int argc, char *argv[]);
@@ -107,6 +108,7 @@ void cl_fixture_cleanup(const char *fixture_name);
  */
 #define cl_fail(desc) clar__fail(__FILE__, __LINE__, "Test failed.", desc, 1)
 #define cl_warning(desc) clar__fail(__FILE__, __LINE__, "Warning during test execution:", desc, 0)
+#define cl_break(desc) clar__broken()
 
 #define cl_skip() clar__skip()
 
@@ -134,6 +136,8 @@ void cl_fixture_cleanup(const char *fixture_name);
 #define cl_assert_equal_p(p1,p2) clar__assert_equal(__FILE__,__LINE__,"Pointer mismatch: " #p1 " != " #p2, 1, "%p", (p1), (p2))
 
 void clar__skip(void);
+
+void clar__broken(void);
 
 void clar__fail(
 	const char *file,

--- a/clar/print.h
+++ b/clar/print.h
@@ -18,7 +18,10 @@ static void clar_print_shutdown(int test_count, int suite_count, int error_count
 
 static void clar_print_error(int num, const struct clar_error *error)
 {
-	printf("  %d) Failure:\n", num);
+	if (error->status == CL_TEST_FAILURE)
+		printf("  %d) Failure:\n", num);
+	else
+		return;
 
 	printf("%s::%s [%s:%d]\n",
 		error->suite,

--- a/clar/print.h
+++ b/clar/print.h
@@ -20,6 +20,8 @@ static void clar_print_error(int num, const struct clar_error *error)
 {
 	if (error->status == CL_TEST_FAILURE)
 		printf("  %d) Failure:\n", num);
+	else if (error->status == CL_TEST_UNBROKEN)
+		printf("  %d) Unbroken:\n", num);
 	else
 		return;
 
@@ -48,6 +50,7 @@ static void clar_print_ontest(const char *test_name, int test_number, enum cl_te
 	case CL_TEST_FAILURE: printf("F"); break;
 	case CL_TEST_SKIP: printf("S"); break;
 	case CL_TEST_BROKEN: printf("B"); break;
+	case CL_TEST_UNBROKEN: printf("U"); break;
 	}
 
 	fflush(stdout);

--- a/clar/print.h
+++ b/clar/print.h
@@ -47,6 +47,7 @@ static void clar_print_ontest(const char *test_name, int test_number, enum cl_te
 	case CL_TEST_OK: printf("."); break;
 	case CL_TEST_FAILURE: printf("F"); break;
 	case CL_TEST_SKIP: printf("S"); break;
+	case CL_TEST_BROKEN: printf("B"); break;
 	}
 
 	fflush(stdout);

--- a/test/main.c
+++ b/test/main.c
@@ -34,7 +34,7 @@ int main(int argc, char *argv[])
 	ret = clar_test(argc, argv);
 
 	/* Your custom cleanup here */
-	cl_assert_equal_i(8, global_test_counter);
+	cl_assert_equal_i(9, global_test_counter);
 
 	return ret;
 }

--- a/test/main.c
+++ b/test/main.c
@@ -34,7 +34,7 @@ int main(int argc, char *argv[])
 	ret = clar_test(argc, argv);
 
 	/* Your custom cleanup here */
-	cl_assert_equal_i(9, global_test_counter);
+	cl_assert_equal_i(11, global_test_counter);
 
 	return ret;
 }

--- a/test/sample.c
+++ b/test/sample.c
@@ -88,3 +88,13 @@ void test_sample__break(void)
 	if (1 != 2)
 		cl_break("Fix numbers!");
 }
+
+void test_sample__expected_breakage(void)
+{
+	cl_must_break(file_size("test/nonexistent") > 0);
+}
+
+void test_sample__unbroken(void)
+{
+	cl_must_break(file_size("test/nonexistent") < 0);
+}

--- a/test/sample.c
+++ b/test/sample.c
@@ -82,3 +82,9 @@ void test_sample__ptr(void)
 	cl_assert_equal_p(actual, actual); /* pointers to same object */
 	cl_assert_equal_p(&actual, actual);
 }
+
+void test_sample__break(void)
+{
+	if (1 != 2)
+		cl_break("Fix numbers!");
+}


### PR DESCRIPTION
So this is mainly inspired by libgit2/libgit2#4129. A known-broken test case has been added which cannot be committed as-is, as it would break our test suite. While it would obviously be possible to just work around this by asserting that it fails, this would not be noticed by anybody who executes the test suite and. Furthermore, if the test is unbroken later on, there will be no immediate indication to the tester that this is actually something good when the test fails.

So this PR implements two new error states: "broken" and "unbroken". Broken represents the case where a test is expected to fail in a known way, that is the system under test is actually broken. The unbroken state is reached when a broken test gets fixed, that is the assert that it is actually broken will not be triggered. These states are represented by the characters "B" and "U" in the test execution. When tests are unbroken, the test will spit out an error at the end of executing all test suites with the label "Unbroken:" instead of "Failed:".