### PR TITLE
generate.py: don't skip files with mtime = 0

### DIFF
--- a/generate.py
+++ b/generate.py
@@ -61,7 +61,7 @@ class Module(object):
     def __init__(self, name):
         self.name = name
 
-        self.mtime = 0
+        self.mtime = None
         self.enabled = True
         self.modified = False
 


### PR DESCRIPTION
TL;DR:

'generate.py' fails to generate tests on file with mtime=0:

```
$ touch --date=@0 clar.{c,h}
$ python generate.py
Traceback (most recent call last):
  File "generate.py", line 242, in <module>
    if suite.write():
  File "generate.py", line 211, in write
    data.write(t.render())
  File "generate.py", line 25, in render
    out = "\n".join("extern %s;" % cb['declaration'] for cb in self.module.callbacks) + "\n"
AttributeError: 'Module' object has no attribute 'callbacks'
```

Long story:

Error happens because 'generate.py' uses '0' as a sentinel value.

In order to enhance reproducibility of builds some build systems
timestamps to a stable date (say, release tarball date).

https://www.gnu.org/software/guix/ goes even farther that that
and sets mtime to '0'. Unfortunately it is exactly the same as
sentinel value in 'generate.py'. That causes 'generate.py' to
treat all test files as "already read".

The change changes value to 'None'.

Signed-off-by: Sergei Trofimovich <slyfox@gentoo.org>