### PR TITLE
Consolidate libgit2 changes

### DIFF
--- a/clar.c
+++ b/clar.c
@@ -313,11 +313,18 @@ clar_parse_args(int argc, char **argv)
 {
 	int i;
 
+	/* Verify options before execute */
 	for (i = 1; i < argc; ++i) {
 		char *argument = argv[i];
 
-		if (argument[0] != '-')
+		if (argument[0] != '-' || argument[1] == '\0'
+		    || strchr("sixvqQl", argument[1]) == NULL) {
 			clar_usage(argv[0]);
+		}
+	}
+
+	for (i = 1; i < argc; ++i) {
+		char *argument = argv[i];
 
 		switch (argument[1]) {
 		case 's':
@@ -391,7 +398,7 @@ clar_parse_args(int argc, char **argv)
 			break;
 
 		default:
-			clar_usage(argv[0]);
+			assert(!"Unexpected commandline argument!");
 		}
 	}
 }

--- a/clar.c
+++ b/clar.c
@@ -422,7 +422,7 @@ clar_test_init(int argc, char **argv)
 }
 
 int
-clar_test_run()
+clar_test_run(void)
 {
 	if (_clar.argc > 1)
 		clar_parse_args(_clar.argc, _clar.argv);
@@ -437,7 +437,7 @@ clar_test_run()
 }
 
 void
-clar_test_shutdown()
+clar_test_shutdown(void)
 {
 	clar_print_shutdown(
 		_clar.tests_ran,

--- a/clar.h
+++ b/clar.h
@@ -12,13 +12,16 @@
 enum cl_test_status {
 	CL_TEST_OK,
 	CL_TEST_FAILURE,
-	CL_TEST_SKIP
+	CL_TEST_SKIP,
+	CL_TEST_NOTRUN,
 };
 
+/** Setup clar environment */
 void clar_test_init(int argc, char *argv[]);
 int clar_test_run(void);
 void clar_test_shutdown(void);
 
+/** One shot setup & run */
 int clar_test(int argc, char *argv[]);
 
 const char *clar_sandbox_path(void);

--- a/clar.h
+++ b/clar.h
@@ -72,6 +72,7 @@ void cl_trace_register(cl_trace_cb *cb, void *payload);
 const char *cl_fixture(const char *fixture_name);
 void cl_fixture_sandbox(const char *fixture_name);
 void cl_fixture_cleanup(const char *fixture_name);
+const char *cl_fixture_basename(const char *fixture_name);
 #endif
 
 /**

--- a/clar/fixtures.h
+++ b/clar/fixtures.h
@@ -20,19 +20,6 @@ fixture_path(const char *base, const char *fixture_name)
 	return _path;
 }
 
-static const char *
-fixture_basename(const char *fixture_name)
-{
-	const char *p;
-
-	for (p = fixture_name; *p; p++) {
-		if (p[0] == '/' && p[1] && p[1] != '/')
-			fixture_name = p+1;
-	}
-
-	return fixture_name;
-}
-
 #ifdef CLAR_FIXTURE_PATH
 const char *cl_fixture(const char *fixture_name)
 {
@@ -44,8 +31,20 @@ void cl_fixture_sandbox(const char *fixture_name)
 	fs_copy(cl_fixture(fixture_name), _clar_path);
 }
 
+const char *cl_fixture_basename(const char *fixture_name)
+{
+	const char *p;
+
+	for (p = fixture_name; *p; p++) {
+		if (p[0] == '/' && p[1] && p[1] != '/')
+			fixture_name = p+1;
+	}
+
+	return fixture_name;
+}
+
 void cl_fixture_cleanup(const char *fixture_name)
 {
-	fs_rm(fixture_path(_clar_path, fixture_basename(fixture_name)));
+	fs_rm(fixture_path(_clar_path, cl_fixture_basename(fixture_name)));
 }
 #endif

--- a/clar/print.h
+++ b/clar/print.h
@@ -13,16 +13,16 @@ static void clar_print_shutdown(int test_count, int suite_count, int error_count
 	(void)error_count;
 
 	printf("\n\n");
-	clar_report_errors();
+	clar_report_all();
 }
 
-static void clar_print_error(int num, const struct clar_error *error)
+static void clar_print_error(int num, const struct clar_report *report, const struct clar_error *error)
 {
 	printf("  %d) Failure:\n", num);
 
 	printf("%s::%s [%s:%d]\n",
-		error->suite,
-		error->test,
+		report->suite,
+		report->test,
 		error->file,
 		error->line_number);
 
@@ -44,6 +44,7 @@ static void clar_print_ontest(const char *test_name, int test_number, enum cl_te
 	case CL_TEST_OK: printf("."); break;
 	case CL_TEST_FAILURE: printf("F"); break;
 	case CL_TEST_SKIP: printf("S"); break;
+	case CL_TEST_NOTRUN: printf("N"); break;
 	}
 
 	fflush(stdout);

--- a/clar/sandbox.h
+++ b/clar/sandbox.h
@@ -1,3 +1,7 @@
+#ifdef __APPLE__
+#include <sys/syslimits.h>
+#endif
+
 static char _clar_path[4096];
 
 static int
@@ -31,6 +35,10 @@ find_tmp_path(char *buffer, size_t length)
 			continue;
 
 		if (is_valid_tmp_path(env)) {
+#ifdef __APPLE__
+			if (length >= PATH_MAX && realpath(env, buffer) != NULL)
+				return 0;
+#endif
 			strncpy(buffer, env, length);
 			return 0;
 		}
@@ -38,6 +46,10 @@ find_tmp_path(char *buffer, size_t length)
 
 	/* If the environment doesn't say anything, try to use /tmp */
 	if (is_valid_tmp_path("/tmp")) {
+#ifdef __APPLE__
+		if (length >= PATH_MAX && realpath("/tmp", buffer) != NULL)
+			return 0;
+#endif
 		strncpy(buffer, "/tmp", length);
 		return 0;
 	}

--- a/clar/summary.h
+++ b/clar/summary.h
@@ -1,0 +1,134 @@
+
+#include <stdio.h>
+#include <time.h>
+
+int clar_summary_close_tag(
+    struct clar_summary *summary, const char *tag, int indent)
+{
+	const char *indt;
+
+	if (indent == 0) indt = "";
+	else if (indent == 1) indt = "\t";
+	else indt = "\t\t";
+
+	return fprintf(summary->fp, "%s</%s>\n", indt, tag);
+}
+
+int clar_summary_testsuites(struct clar_summary *summary)
+{
+	return fprintf(summary->fp, "<testsuites>\n");
+}
+
+int clar_summary_testsuite(struct clar_summary *summary,
+    int idn, const char *name, const char *pkg, time_t timestamp,
+    double elapsed, int test_count, int fail_count, int error_count)
+{
+	struct tm *tm = localtime(&timestamp);
+	char iso_dt[20];
+
+	if (strftime(iso_dt, sizeof(iso_dt), "%Y-%m-%dT%H:%M:%S", tm) == 0)
+		return -1;
+
+	return fprintf(summary->fp, "\t<testsuite "
+		       " id=\"%d\""
+		       " name=\"%s\""
+		       " package=\"%s\""
+		       " hostname=\"localhost\""
+		       " timestamp=\"%s\""
+		       " time=\"%.2f\""
+		       " tests=\"%d\""
+		       " failures=\"%d\""
+		       " errors=\"%d\">\n",
+		       idn, name, pkg, iso_dt, elapsed, test_count, fail_count, error_count);
+}
+
+int clar_summary_testcase(struct clar_summary *summary,
+    const char *name, const char *classname, double elapsed)
+{
+	return fprintf(summary->fp,
+	    "\t\t<testcase name=\"%s\" classname=\"%s\" time=\"%.2f\">\n",
+		name, classname, elapsed);
+}
+
+int clar_summary_failure(struct clar_summary *summary,
+    const char *type, const char *message, const char *desc)
+{
+	return fprintf(summary->fp,
+	    "\t\t\t<failure type=\"%s\"><![CDATA[%s\n%s]]></failure>\n",
+	    type, message, desc);
+}
+
+struct clar_summary *clar_summary_init(const char *filename)
+{
+	struct clar_summary *summary;
+	FILE *fp;
+
+	if ((fp = fopen(filename, "w")) == NULL)
+		return NULL;
+
+	if ((summary = malloc(sizeof(struct clar_summary))) == NULL) {
+		fclose(fp);
+		return NULL;
+	}
+
+	summary->filename = filename;
+	summary->fp = fp;
+
+	return summary;
+}
+
+int clar_summary_shutdown(struct clar_summary *summary)
+{
+	struct clar_report *report;
+	const char *last_suite = NULL;
+
+	if (clar_summary_testsuites(summary) < 0)
+		goto on_error;
+
+	report = _clar.reports;
+	while (report != NULL) {
+		struct clar_error *error = report->errors;
+
+		if (last_suite == NULL || strcmp(last_suite, report->suite) != 0) {
+			if (clar_summary_testsuite(summary, 0, report->suite, "",
+			    time(NULL), 0, _clar.tests_ran, _clar.total_errors, 0) < 0)
+				goto on_error;
+		}
+
+		last_suite = report->suite;
+
+		clar_summary_testcase(summary, report->test, "what", 0);
+
+		while (error != NULL) {
+			if (clar_summary_failure(summary, "assert",
+			    error->error_msg, error->description) < 0)
+				goto on_error;
+
+			error = error->next;
+		}
+
+		if (clar_summary_close_tag(summary, "testcase", 2) < 0)
+			goto on_error;
+
+		report = report->next;
+
+		if (!report || strcmp(last_suite, report->suite) != 0) {
+			if (clar_summary_close_tag(summary, "testsuite", 1) < 0)
+				goto on_error;
+		}
+	}
+
+	if (clar_summary_close_tag(summary, "testsuites", 0) < 0 ||
+	    fclose(summary->fp) != 0)
+		goto on_error;
+
+	printf("written summary file to %s\n", summary->filename);
+
+	free(summary);
+	return 0;
+
+on_error:
+	fclose(summary->fp);
+	free(summary);
+	return -1;
+}

--- a/generate.py
+++ b/generate.py
@@ -8,7 +8,7 @@
 
 from __future__ import with_statement
 from string import Template
-import re, fnmatch, os, codecs, pickle
+import re, fnmatch, os, sys, codecs, pickle
 
 class Module(object):
     class Template(object):
@@ -128,8 +128,9 @@ class Module(object):
 
 class TestSuite(object):
 
-    def __init__(self, path):
+    def __init__(self, path, output):
         self.path = path
+        self.output = output
 
     def should_generate(self, path):
         if not os.path.isfile(path):
@@ -157,7 +158,7 @@ class TestSuite(object):
         return modules
 
     def load_cache(self):
-        path = os.path.join(self.path, '.clarcache')
+        path = os.path.join(self.output, '.clarcache')
         cache = {}
 
         try:
@@ -170,7 +171,7 @@ class TestSuite(object):
         return cache
 
     def save_cache(self):
-        path = os.path.join(self.path, '.clarcache')
+        path = os.path.join(self.output, '.clarcache')
         with open(path, 'wb') as cache:
             pickle.dump(self.modules, cache)
 
@@ -200,7 +201,7 @@ class TestSuite(object):
         return sum(len(module.callbacks) for module in self.modules.values())
 
     def write(self):
-        output = os.path.join(self.path, 'clar.suite')
+        output = os.path.join(self.output, 'clar.suite')
 
         if not self.should_generate(output):
             return False
@@ -232,13 +233,18 @@ if __name__ == '__main__':
     parser = OptionParser()
     parser.add_option('-f', '--force', action="store_true", dest='force', default=False)
     parser.add_option('-x', '--exclude', dest='excluded', action='append', default=[])
+    parser.add_option('-o', '--output', dest='output')
 
     options, args = parser.parse_args()
+    if len(args) > 1:
+        print("More than one path given")
+        sys.exit(1)
 
-    for path in args or ['.']:
-        suite = TestSuite(path)
-        suite.load(options.force)
-        suite.disable(options.excluded)
-        if suite.write():
-            print("Written `clar.suite` (%d tests in %d suites)" % (suite.callback_count(), suite.suite_count()))
+    path = args.pop() if args else '.'
+    output = options.output or path
+    suite = TestSuite(path, output)
+    suite.load(options.force)
+    suite.disable(options.excluded)
+    if suite.write():
+        print("Written `clar.suite` (%d tests in %d suites)" % (suite.callback_count(), suite.suite_count()))
 

--- a/generate.py
+++ b/generate.py
@@ -222,16 +222,18 @@ class TestSuite(object):
             return False
 
         with open(output, 'w') as data:
-            for module in self.modules.values():
+            modules = sorted(self.modules.values(), key=lambda module: module.name)
+
+            for module in modules:
                 t = Module.DeclarationTemplate(module)
                 data.write(t.render())
 
-            for module in self.modules.values():
+            for module in modules:
                 t = Module.CallbacksTemplate(module)
                 data.write(t.render())
 
             suites = "static struct clar_suite _clar_suites[] = {" + ','.join(
-                Module.InfoTemplate(module).render() for module in sorted(self.modules.values(), key=lambda module: module.name)
+                Module.InfoTemplate(module).render() for module in modules
             ) + "\n};\n"
 
             data.write(suites)


### PR DESCRIPTION
This is an attempt at consolidating changes made to `libgit2`'s clar somewhere, I'm filing it mostly for reference and to have the list handy (I had started a few month ago, but the recent discussion spurred me to finish it). Changes might have been applied in a different order though.

Copying the current clar files from `libgit2` on top of this will result in this diff, so I think I missed a commit somewhere :

```diff
diff --git i/generate.py w/generate.py
index 993fb274e..572a57f86 100755
--- i/generate.py
+++ w/generate.py
@@ -76,7 +76,7 @@ def render(self):
     def __init__(self, name):
         self.name = name
 
-        self.mtime = None
+        self.mtime = 0
         self.enabled = True
         self.modified = False
 
@@ -222,16 +222,18 @@ def write(self):
             return False
 
         with open(output, 'w') as data:
-            for module in self.modules.values():
+            modules = sorted(self.modules.values(), key=lambda module: module.name)
+
+            for module in modules:
                 t = Module.DeclarationTemplate(module)
                 data.write(t.render())
 
-            for module in self.modules.values():
+            for module in modules:
                 t = Module.CallbacksTemplate(module)
                 data.write(t.render())
 
             suites = "static struct clar_suite _clar_suites[] = {" + ','.join(
-                Module.InfoTemplate(module).render() for module in sorted(self.modules.values(), key=lambda module: module.name)
+                Module.InfoTemplate(module).render() for module in modules
             ) + "\n};\n"
 
             data.write(suites)

```